### PR TITLE
Eval locals at runtime, not compile-time

### DIFF
--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -4,17 +4,18 @@
 
 (defn- save-env [bindings form]
   (if bindings
-    `(let ~(vec (apply concat (for [b bindings]
-                                [(.sym b) (.eval (.init b))])))
-       (~@form))
-    form))
+    `(list `let ~(vec (apply concat (for [b bindings]
+                                      [`(quote ~(.sym b))
+                                       (.sym b)])))
+           '~form)
+    `'~form))
 
 (defmacro ^{:doc (str (:doc (meta #'clojure.core/fn))
                       "\n\n  Oh, but it also allows serialization!!!111eleven")}
   fn [& sigs]
   `(with-meta (clojure.core/fn ~@sigs)
      {:type ::serializable-fn
-      ::source (quote ~(save-env (vals &env) &form))}))
+      ::source ~(save-env (vals &env) &form)}))
 
 (defmethod print-method ::serializable-fn [o ^Writer w]
   (print-method (::source (meta o)) w))

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -25,10 +25,25 @@
   (is (number? (:line (meta (:serializable.fn/source
                              (meta dinc)))))))
 
+(defn round-trip [f & args]
+  (apply (eval (read-string (pr-str f))) args))
+
 (deftest serializable-fn-roundtrip!!!111eleven
-  (is (= 2 ((eval (read-string (pr-str dinc))) 0))))
+  (is (= 2 (round-trip dinc 0))))
 
 (deftest serializable-roundtrip-with-lexical-context
   (let [x 0, y (+ 95 4)]
     (is (= [2 100]
-           ((eval (read-string (pr-str (fn [] [(dinc x) (inc y)])))))))))
+           (round-trip (fn [] [(dinc x) (inc y)]))))))
+
+(deftest roundtrip-with-lexical-nonconst-context
+  (let [x 10, y (inc x)]
+    (is (= 11
+           (round-trip (fn [] y))))))
+
+(deftest roundtrip-with-fnarg-context
+  (is (= 11
+         (round-trip ((fn [x]
+                        (let [y (inc x)]
+                          (fn [] y)))
+                      10)))))


### PR DESCRIPTION
Now we can serialize functions like this:

``` clojure
(let [x 10, y (inc x)]
  (fn [] y))
```

Previously that failed, because an attempt was made to eval `y` by evaluating `(inc x)`, but at compile-time x is not defined. 

I added tests for the new behavior, which pass; however, one of the old tests fails because it cannot resolve `dinc`. I tried rolling back all my changes, and that test still fails; not sure what's going on there.
