### PR TITLE
Multiple round-trips

### DIFF
--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -3,12 +3,15 @@
   (:refer-clojure :exclude [fn]))
 
 (defn- save-env [bindings form]
-  (if bindings
-    `(list `let ~(vec (apply concat (for [b bindings]
-                                      [`(quote ~(.sym b))
-                                       (.sym b)])))
-           '~form)
-    `'~form))
+  (let [form (with-meta (cons `fn (rest form)) ; serializable/fn, not core/fn
+               (meta form))
+        quoted-form `(quote ~form)]
+    (if bindings
+      `(list `let ~(vec (apply concat (for [b bindings]
+                                        [`(quote ~(.sym b))
+                                         (.sym b)])))
+             ~quoted-form)
+      quoted-form)))
 
 (defmacro ^{:doc (str (:doc (meta #'clojure.core/fn))
                       "\n\n  Oh, but it also allows serialization!!!111eleven")}

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -3,7 +3,7 @@
   (:use [serializable.fn]
         [clojure.test]))
 
-(def dinc-list '(fn [x] (inc (inc x))))
+(def dinc-list '(serializable.fn/fn [x] (inc (inc x))))
 
 (def dinc (eval dinc-list))
 

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -25,8 +25,10 @@
   (is (number? (:line (meta (:serializable.fn/source
                              (meta dinc)))))))
 
+(def write+read (comp eval read-string pr-str))
+
 (defn round-trip [f & args]
-  (apply (eval (read-string (pr-str f))) args))
+  (apply (write+read f) args))
 
 (deftest serializable-fn-roundtrip!!!111eleven
   (is (= 2 (round-trip dinc 0))))
@@ -42,3 +44,8 @@
                         (let [y (inc x)]
                           (fn [] y)))
                       10)))))
+
+(deftest roundtrip-twice!
+  (is (= 5
+         ((write+read (write+read (let [x 5]
+                                    (fn [] x))))))))

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -31,11 +31,6 @@
 (deftest serializable-fn-roundtrip!!!111eleven
   (is (= 2 (round-trip dinc 0))))
 
-(deftest serializable-roundtrip-with-lexical-context
-  (let [x 0, y (+ 95 4)]
-    (is (= [2 100]
-           (round-trip (fn [] [(dinc x) (inc y)]))))))
-
 (deftest roundtrip-with-lexical-nonconst-context
   (let [x 10, y (inc x)]
     (is (= 11


### PR DESCRIPTION
Added a test that you can go through the pr-str/read loop multiple times in a row. Test failed; fixed implementation.
