### PR TITLE
Import for type hint

### DIFF
--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -1,6 +1,7 @@
 (ns serializable.fn
   "Serializable functions! Check it out."
-  (:refer-clojure :exclude [fn]))
+  (:refer-clojure :exclude [fn])
+  (:import java.io.Writer))
 
 (defn- save-env [bindings form]
   (let [form (with-meta (cons `fn (rest form)) ; serializable/fn, not core/fn


### PR DESCRIPTION
Maybe project.clj should be updated to depend on Clojure 1.3.0 so that tests will fail on future such things?
