### PR TITLE
Fix/improve closures

### DIFF
--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -8,9 +8,10 @@
                (meta form))
         quoted-form `(quote ~form)]
     (if bindings
-      `(list `let ~(vec (apply concat (for [b bindings]
-                                        [`(quote ~(.sym b))
-                                         (.sym b)])))
+      `(list `let ~(vec (apply concat (for [b bindings
+                                            :let [sym (.sym b)]]
+                                        [`(quote ~sym)
+                                         `(list `quote ~sym)])))
              ~quoted-form)
       quoted-form)))
 

--- a/test/serializable/fn_test.clj
+++ b/test/serializable/fn_test.clj
@@ -49,3 +49,6 @@
   (is (= 5
          ((write+read (write+read (let [x 5]
                                     (fn [] x))))))))
+
+(deftest roundtrip-with-lexical-context-needs-quoting
+  (is (= 'foo (round-trip (let [x 'foo] (fn [] x))))))


### PR DESCRIPTION
@Raynes noticed the values output by the serialization of a closure need to be quoted. This patch does that and adds a test asserting that it works.
