### PR TITLE
More portable/reliable implementation; no feature changes

### DIFF
--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -3,15 +3,14 @@
   (:refer-clojure :exclude [fn])
   (:import java.io.Writer))
 
-(defn- save-env [bindings form]
+(defn- save-env [locals form]
   (let [form (with-meta (cons `fn (rest form)) ; serializable/fn, not core/fn
                (meta form))
         quoted-form `(quote ~form)]
-    (if bindings
-      `(list `let ~(vec (apply concat (for [b bindings
-                                            :let [sym (.sym b)]]
-                                        [`(quote ~sym)
-                                         `(list `quote ~sym)])))
+    (if locals
+      `(list `let ~(vec (apply concat (for [local locals]
+                                        [`(quote ~local)
+                                         `(list `quote ~local)])))
              ~quoted-form)
       quoted-form)))
 
@@ -20,7 +19,7 @@
   fn [& sigs]
   `(with-meta (clojure.core/fn ~@sigs)
      {:type ::serializable-fn
-      ::source ~(save-env (vals &env) &form)}))
+      ::source ~(save-env (keys &env) &form)}))
 
 (defmethod print-method ::serializable-fn [o ^Writer w]
   (print-method (::source (meta o)) w))

--- a/src/serializable/fn.clj
+++ b/src/serializable/fn.clj
@@ -8,9 +8,10 @@
                (meta form))
         quoted-form `(quote ~form)]
     (if locals
-      `(list `let ~(vec (apply concat (for [local locals]
-                                        [`(quote ~local)
-                                         `(list `quote ~local)])))
+      `(list `let [~@(for [local locals,
+                           let-arg [`(quote ~local)
+                                    `(list `quote ~local)]]
+                       let-arg)]
              ~quoted-form)
       quoted-form)))
 


### PR DESCRIPTION
The vals we were using are undefined behavior that will break someday.
